### PR TITLE
Fixed typos

### DIFF
--- a/description.md
+++ b/description.md
@@ -546,11 +546,11 @@ The example demonstrates the principles of how the predicate calldata is assembl
 
 ```javascript
 // Predicate = (5 < call result < 15) = or(5 < call result, 15 > call result)
-const arbitaryFunction = arbitraryPredicate.interface.encodeFunctionData('copyArg', [10]);
-// Create predicate:  (arbitary call result < 15 || arbitary call result > 5)
+const arbitraryFunction = arbitraryPredicate.interface.encodeFunctionData('copyArg', [10]);
+// Create predicate:  (arbitrary call result < 15 || arbitrary call result > 5)
 const arbitraryCallPredicate = swap.interface.encodeFunctionData('arbitraryStaticCall', [
     arbitraryPredicate.address,
-    arbitaryFunction,
+    arbitraryFunction,
 ]);
 const comparelt = swap.interface.encodeFunctionData('lt', [15, arbitraryCallPredicate]);
 const comparegt = swap.interface.encodeFunctionData('gt', [5, arbitraryCallPredicate]);

--- a/docs/LimitOrderProtocol.md
+++ b/docs/LimitOrderProtocol.md
@@ -15,7 +15,7 @@ See [OrderMixin](OrderMixin.md) for more details.
 
 RFQ orders supports
 - Expiration time
-- Cancelation by order id
+- Cancellation by order id
 - Partial Fill (only once)
 
 See [OrderMixin](OrderMixin.md) for more details.


### PR DESCRIPTION
### Changes

1. **File:** `/description.md`
    - Fixed `arbitary` to `arbitrary` (Line 550)
1. **File:** `/docs/LimitOrderProtocol.md`
    - Fixed `Cancelation` to `Cancellation` (Line 18)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.